### PR TITLE
More elegant way to add repository

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,17 +43,9 @@ dependencies {
 - Select "Library dependency"
 - Enter `org.mozilla.iot:webthing` in the search bar and search
 - Select the package in the result and confirm with "OK"
+- Go to "Project"
+- Add `, 'https://www.jitpack.io'` to "Default Library Repository" field
 - Click "OK" in the Project Structure dialog
-- Add `maven { url 'https://www.jitpack.io' }` to the repositories in the project gradle config (should be in the sidebar under "Gradle Scripts", the one annotated with "(Project: Your project name)". If you have the default configuration, the section will look as follows:
-```gradle
-allprojects {
-    repositories {
-        google()
-        jcenter()
-        maven { url 'https://www.jitpack.io' }
-    }
-}
-```
 
 # Example
 


### PR DESCRIPTION
I just found out that there's a way nicer way to add repositories in Android studio. I forgot that Java IDEs tend to have a GUI for everything.