### PR TITLE
Try to get a non-loopback IP

### DIFF
--- a/src/main/java/org/mozilla/iot/webthing/Utils.java
+++ b/src/main/java/org/mozilla/iot/webthing/Utils.java
@@ -4,8 +4,12 @@
 package org.mozilla.iot.webthing;
 
 import java.net.Inet4Address;
+import java.net.InetAddress;
+import java.net.NetworkInterface;
 import java.net.UnknownHostException;
+import java.net.SocketException;
 import java.time.Instant;
+import java.util.Enumeration;
 
 public class Utils {
     /**
@@ -15,10 +19,31 @@ public class Utils {
      */
     public static String getIP() {
         try {
-            return Inet4Address.getLocalHost().getHostAddress();
+            final InetAddress address = Inet4Address.getLocalHost();
+            if (isValidAddress(address)) {
+                return formatAddress(address);
+            }
         } catch (UnknownHostException e) {
-            return null;
+            // fall through
         }
+        try {
+            final Enumeration interfaces = NetworkInterface.getNetworkInterfaces();
+            while (interfaces.hasMoreElements()) {
+                final NetworkInterface iface =
+                        (NetworkInterface)interfaces.nextElement();
+                final Enumeration addresses = iface.getInetAddresses();
+                while (addresses.hasMoreElements()) {
+                    final InetAddress address = (InetAddress)addresses.nextElement();
+                    if (!isValidAddress(address)) {
+                        continue;
+                    }
+                    return formatAddress(address);
+                }
+            }
+        } catch (SocketException e) {
+            // return null
+        }
+        return null;
     }
 
     /**
@@ -29,5 +54,30 @@ public class Utils {
     public static String timestamp() {
         String now = Instant.now().toString().split("\\.")[0];
         return now + "+00:00";
+    }
+
+    /**
+     * Ensures the address is not a local loopback or multicast address and has
+     * no IPv6 scope.
+     *
+     * @param address Address to check.
+     * @return True if the address is not a loopback, multicast or IPv6 with scope address.
+     */
+    private static boolean isValidAddress(InetAddress address) {
+        return !address.isLoopbackAddress() && !address.isMulticastAddress() && !address.getHostAddress().contains("%");
+    }
+
+    /**
+     * Format the address for consumption by browsers.
+     *
+     * @param address
+     * @return IPv6 address in square brackets, IPv4 address just as IP string.
+     */
+    private static String formatAddress(InetAddress address) {
+        final String hostname = address.getHostAddress();
+        if (hostname.contains(":")) {
+            return "[" + hostname + "]";
+        }
+        return hostname;
     }
 }


### PR DESCRIPTION
This fixes `Util.getIP()` to not return a loopback IP if at all possible and to properly format IPv6 addresses.

This makes my Webthingify project work properly with the gateway, including mDNS:
![image](https://user-images.githubusercontent.com/640949/48208564-64ff5780-e373-11e8-954a-0b7c9ed826cd.png)

I have a branch that merges this with #30 to test it, called "preview", which is what I tested this with.