### PR TITLE
If server's hostname is set, JmDNS will listen to same hostname

### DIFF
--- a/src/main/java/org/mozilla/iot/webthing/WebThingServer.java
+++ b/src/main/java/org/mozilla/iot/webthing/WebThingServer.java
@@ -255,7 +255,8 @@ public class WebThingServer extends RouterNanoHTTPD {
      * @throws IOException on failure to listen on port
      */
     public void start(boolean daemon) throws IOException {
-        this.jmdns = JmDNS.create(InetAddress.getLocalHost());
+        this.jmdns = JmDNS.create(hostname == null ? InetAddress.getLocalHost()
+                                                   : InetAddress.getByName(hostname));
 
         String systemHostname = this.jmdns.getHostName();
         if (systemHostname.endsWith(".")) {


### PR DESCRIPTION
JmDNS will always listen to localhost even when providing a hostname to WebThingServer.
Webserver start will fail when the localhost is not available (can happens for example in some docker environments)

The fix is to use server hostname if provided when creating JmDNS object.