### PR TITLE
Support floating-point numbers without a fractional part

### DIFF
--- a/src/main/java/io/webthings/webthing/Property.java
+++ b/src/main/java/io/webthings/webthing/Property.java
@@ -171,4 +171,14 @@ public class Property<T> {
     public JSONObject getMetadata() {
         return this.metadata;
     }
+
+    /**
+     * Get the base type of this properties value.
+     *
+     * @return The base type.
+     */
+    public Class<T> getBaseType()
+    {
+        return value.getBaseType();
+    }
 }

--- a/src/main/java/io/webthings/webthing/Thing.java
+++ b/src/main/java/io/webthings/webthing/Thing.java
@@ -17,6 +17,7 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
 
 import io.webthings.webthing.errors.PropertyError;
@@ -399,10 +400,9 @@ public class Thing {
             return;
         }
 
-        if(value instanceof Integer
-            && prop.getMetadata().optString("type").equalsIgnoreCase("number"))
-        {
-            setProperty(propertyName,  ((Integer) value).doubleValue());
+        Optional<Object> converted = Utils.checkIfBaseTypeConversionIsRequired(prop.getBaseType(), value);
+        if(converted.isPresent()) {
+            setProperty(propertyName, converted.get());
             return;
         }
 

--- a/src/main/java/io/webthings/webthing/Thing.java
+++ b/src/main/java/io/webthings/webthing/Thing.java
@@ -399,6 +399,13 @@ public class Thing {
             return;
         }
 
+        if(value instanceof Integer
+            && prop.getMetadata().optString("type").equalsIgnoreCase("number"))
+        {
+            setProperty(propertyName,  ((Integer) value).doubleValue());
+            return;
+        }
+
         prop.setValue(value);
     }
 

--- a/src/main/java/io/webthings/webthing/Utils.java
+++ b/src/main/java/io/webthings/webthing/Utils.java
@@ -10,6 +10,7 @@ import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -65,12 +66,16 @@ public class Utils {
         return ret;
     }
 
-    final static Map<Class<?>, Function<Number, Object>> supportedNumberConverters = Map.of(
-        Integer.class, n -> n.intValue(),
-        Long.class, n -> n.longValue(),
-        Float.class, n -> n.floatValue(),
-        Double.class, n -> n.doubleValue()
-    );
+    static Map<Class<?>, Function<Number, Object>> createNumberConverters()
+    {
+        Map<Class<?>, Function<Number, Object>> converters = new HashMap<>();
+        converters.put(Integer.class, n -> n.intValue());
+        converters.put(Long.class, n -> n.longValue());
+        converters.put(Float.class, n -> n.floatValue());
+        converters.put(Double.class, n -> n.doubleValue());
+        return converters;
+    }
+    final static Map<Class<?>, Function<Number, Object>> supportedNumberConverters = createNumberConverters();
 
     /**
      * Performes a type conversion when required.

--- a/src/main/java/io/webthings/webthing/Utils.java
+++ b/src/main/java/io/webthings/webthing/Utils.java
@@ -12,7 +12,10 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Optional;
 import java.util.Set;
+import java.util.function.Function;
 
 public class Utils {
     /**
@@ -60,5 +63,27 @@ public class Utils {
         List<String> ret = new ArrayList<>(addresses);
         Collections.sort(ret);
         return ret;
+    }
+
+    final static Map<Class<?>, Function<Number, Object>> supportedNumberConverters = Map.of(
+        Integer.class, n -> n.intValue(),
+        Long.class, n -> n.longValue(),
+        Float.class, n -> n.floatValue(),
+        Double.class, n -> n.doubleValue()
+    );
+
+    /**
+     * Performes a type conversion when required.
+     * @param baseTypeClass The Class of the base type to check agains
+     * @param value         Value that might need conversion
+     * @return Optional containing converted value or empty Optional when no conversion was required.
+     */
+    public static <T> Optional<Object>  checkIfBaseTypeConversionIsRequired(Class<?> baseTypeClass, T value) {
+        if(value instanceof Number && baseTypeClass != value.getClass()) {
+            if(Number.class.isAssignableFrom(baseTypeClass)) {
+                return Optional.ofNullable(supportedNumberConverters.get(baseTypeClass)).map(f -> f.apply((Number) value));
+            }
+        }
+        return Optional.empty();
     }
 }

--- a/src/test/java/io/webthings/webthing/ThingTest.java
+++ b/src/test/java/io/webthings/webthing/ThingTest.java
@@ -4,7 +4,9 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import java.util.List;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
 import java.util.Map;
 
 import org.json.JSONArray;
@@ -156,10 +158,13 @@ public class ThingTest {
         thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "object")));
         
         // when updating property, then
-        assertEquals(Map.of("key1", "val1", "key2", "val2"), value.get().toMap());
+        Map<String, Object> expectedMap = new HashMap<>();
+        expectedMap.put("key1", "val1");
+        expectedMap.put("key2", "val2");
+        assertEquals(expectedMap, value.get().toMap());
 
         thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":{\"key3\":\"val3\"}}"));
-        assertEquals(Map.of("key3", "val3"), value.get().toMap());
+        assertEquals(Collections.singletonMap("key3", "val3"), value.get().toMap());
     }
 
     @Test
@@ -172,10 +177,10 @@ public class ThingTest {
         thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "array")));
         
         // when updating property, then
-        assertEquals(List.of(1,2,3), value.get().toList());
+        assertEquals(Arrays.asList(1,2,3), value.get().toList());
 
         thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":[]}"));
-        assertEquals(List.of(), value.get().toList());
+        assertEquals(Arrays.asList(), value.get().toList());
     }
 
     @Test

--- a/src/test/java/io/webthings/webthing/ThingTest.java
+++ b/src/test/java/io/webthings/webthing/ThingTest.java
@@ -1,0 +1,72 @@
+package io.webthings.webthing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
+
+import org.json.JSONObject;
+import org.junit.Test;
+
+import io.webthings.webthing.errors.PropertyError;
+
+public class ThingTest {
+
+    Object simulateHttpPutProperty(String key, String jsonBody) {
+        JSONObject json = new JSONObject(jsonBody);
+        return json.get(key);
+    }
+
+    @Test
+    public void ItSupportsIntegralInputForFractionalProperties() throws PropertyError {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<Integer> intValue = new Value<>(456,
+            iv -> System.out.println("integer value: " + iv));
+        thing.addProperty(new Property<>(thing, "intProp", intValue,
+            new JSONObject().put("type", "integer")));
+
+        Value<Double> doubleValue = new Value<>(12.34,
+            dv -> System.out.println("doubel value: " + dv));
+        thing.addProperty(new Property<>(thing, "doubleProp", doubleValue,
+            new JSONObject().put("type", "number")));
+
+        Value<Float> floatValue = new Value<>(4.2f,
+            fv -> System.out.println("float value: " + fv));
+        thing.addProperty(new Property<>(thing, "floatProp", floatValue,
+            new JSONObject().put("type", "number")));
+
+        // when updating integer property, then
+        assertEquals(Integer.valueOf(456), intValue.get());
+
+        Exception ex = assertThrows(PropertyError.class, () -> thing.setProperty("intProp", 
+            simulateHttpPutProperty("intProp", "{\"intProp\":42.0}")));
+        assertEquals(ex.getMessage(), "Invalid property value");
+        assertEquals(Integer.valueOf(456), intValue.get());
+
+        thing.setProperty("intProp", 
+            simulateHttpPutProperty("intProp", "{\"intProp\":24}"));
+        assertEquals(Integer.valueOf(24), intValue.get());
+
+        // when updating double property, then
+        assertEquals(12.34, doubleValue.get(), 0.00001);
+
+        thing.setProperty("doubleProp", 
+            simulateHttpPutProperty("doubleProp", "{\"doubleProp\":42.0}"));
+        assertEquals(42.0, doubleValue.get(), 0.00001);
+
+        thing.setProperty("doubleProp", 
+            simulateHttpPutProperty("doubleProp", "{\"doubleProp\":24}"));
+        assertEquals(24.0, doubleValue.get(), 0.00001);
+
+        // when updating float property, then
+        assertEquals(4.2f, floatValue.get(), 0.00001);
+
+        thing.setProperty("floatProp", 
+            simulateHttpPutProperty("floatProp", "{\"floatProp\":2.4}"));
+        assertEquals(42.0f, floatValue.get(), 0.00001);
+
+        thing.setProperty("floatProp", 
+            simulateHttpPutProperty("floatProp", "{\"floatProp\":4}"));
+        assertEquals(4.0f, floatValue.get(), 0.00001);
+    }
+}

--- a/src/test/java/io/webthings/webthing/ThingTest.java
+++ b/src/test/java/io/webthings/webthing/ThingTest.java
@@ -1,8 +1,13 @@
 package io.webthings.webthing;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONArray;
 import org.json.JSONObject;
 import org.junit.Test;
 
@@ -16,57 +21,192 @@ public class ThingTest {
     }
 
     @Test
-    public void ItSupportsIntegralInputForFractionalProperties() throws PropertyError {
+    public void itSupportsIntegerValues() throws PropertyError
+    {
         // given
         Thing thing = new Thing("urn:dev:test-123", "My TestThing");
 
-        Value<Integer> intValue = new Value<>(456,
-            iv -> System.out.println("integer value: " + iv));
-        thing.addProperty(new Property<>(thing, "intProp", intValue,
-            new JSONObject().put("type", "integer")));
+        Value<Integer> value = new Value<>(42, v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "integer")));
+        
+        // when updating property, then
+        assertEquals(42, value.get().intValue());
 
-        Value<Double> doubleValue = new Value<>(12.34,
-            dv -> System.out.println("doubel value: " + dv));
-        thing.addProperty(new Property<>(thing, "doubleProp", doubleValue,
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Integer.MIN_VALUE+"}"));
+        assertEquals(Integer.MIN_VALUE, value.get().intValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Integer.MAX_VALUE+"}"));
+        assertEquals(Integer.MAX_VALUE, value.get().intValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4.2}"));
+        assertEquals(4, value.get().intValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4}"));
+        assertEquals(4, value.get().intValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":0}"));
+        assertEquals(0, value.get().intValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":-123}"));
+        assertEquals(-123, value.get().intValue());
+    }
+
+    @Test
+    public void itSupportsLongValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<Long> value = new Value<>(42l, v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "integer")));
+        
+        // when updating property, then
+        assertEquals(42, value.get().longValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Long.MIN_VALUE+"}"));
+        assertEquals(Long.MIN_VALUE, value.get().longValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Long.MAX_VALUE+"}"));
+        assertEquals(Long.MAX_VALUE, value.get().longValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4.2}"));
+        assertEquals(4, value.get().longValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4}"));
+        assertEquals(4, value.get().longValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":0}"));
+        assertEquals(0, value.get().longValue());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":-123}"));
+        assertEquals(-123, value.get().longValue());
+    }
+
+    @Test
+    public void itSupportsFloatValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<Float> value = new Value<>(42.0123f, v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value,
             new JSONObject().put("type", "number")));
+        
+        // when updating property, then
+        assertEquals(42.0123f, value.get().floatValue(), 0.00001);
 
-        Value<Float> floatValue = new Value<>(4.2f,
-            fv -> System.out.println("float value: " + fv));
-        thing.addProperty(new Property<>(thing, "floatProp", floatValue,
-            new JSONObject().put("type", "number")));
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Float.MIN_VALUE+"}"));
+        assertEquals(Float.MIN_VALUE, value.get().floatValue(), 0.00001);
 
-        // when updating integer property, then
-        assertEquals(Integer.valueOf(456), intValue.get());
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Float.MAX_VALUE+"}"));
+        assertEquals(Float.MAX_VALUE, value.get().floatValue(), 0.00001);
 
-        Exception ex = assertThrows(PropertyError.class, () -> thing.setProperty("intProp", 
-            simulateHttpPutProperty("intProp", "{\"intProp\":42.0}")));
-        assertEquals(ex.getMessage(), "Invalid property value");
-        assertEquals(Integer.valueOf(456), intValue.get());
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4.2}"));
+        assertEquals(4.2f, value.get().floatValue(), 0.00001);
 
-        thing.setProperty("intProp", 
-            simulateHttpPutProperty("intProp", "{\"intProp\":24}"));
-        assertEquals(Integer.valueOf(24), intValue.get());
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4}"));
+        assertEquals(4f, value.get().floatValue(), 0.00001);
 
-        // when updating double property, then
-        assertEquals(12.34, doubleValue.get(), 0.00001);
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":0}"));
+        assertEquals(0f, value.get().floatValue(), 0.00001);
 
-        thing.setProperty("doubleProp", 
-            simulateHttpPutProperty("doubleProp", "{\"doubleProp\":42.0}"));
-        assertEquals(42.0, doubleValue.get(), 0.00001);
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":-123.456}"));
+        assertEquals(-123.456f, value.get().floatValue(), 0.00001);
+    }
 
-        thing.setProperty("doubleProp", 
-            simulateHttpPutProperty("doubleProp", "{\"doubleProp\":24}"));
-        assertEquals(24.0, doubleValue.get(), 0.00001);
+    @Test
+    public void itSupportsDoubleValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
 
-        // when updating float property, then
-        assertEquals(4.2f, floatValue.get(), 0.00001);
+        Value<Double> value = new Value<>(42.0123, v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "number")));
+        
+        // when updating property, then
+        assertEquals(42.0123, value.get(), 0.00001);
 
-        thing.setProperty("floatProp", 
-            simulateHttpPutProperty("floatProp", "{\"floatProp\":2.4}"));
-        assertEquals(42.0f, floatValue.get(), 0.00001);
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Double.MIN_VALUE+"}"));
+        assertEquals(Double.MIN_VALUE, value.get(), 0.0000000001);
 
-        thing.setProperty("floatProp", 
-            simulateHttpPutProperty("floatProp", "{\"floatProp\":4}"));
-        assertEquals(4.0f, floatValue.get(), 0.00001);
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":"+Double.MAX_VALUE+"}"));
+        assertEquals(Double.MAX_VALUE, value.get(), 0.0000000001);
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4.2}"));
+        assertEquals(4.2, value.get(), 0.00001);
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":4}"));
+        assertEquals(4, value.get(), 0.00001);
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":0}"));
+        assertEquals(0, value.get(), 0.00001);
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":-123.456}"));
+        assertEquals(-123.456, value.get(), 0.00001);
+    }
+
+    @Test
+    public void itSupportsObjectValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<JSONObject> value = new Value<>(new JSONObject().put("key1", "val1").put("key2", "val2"),
+            v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "object")));
+        
+        // when updating property, then
+        assertEquals(Map.of("key1", "val1", "key2", "val2"), value.get().toMap());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":{\"key3\":\"val3\"}}"));
+        assertEquals(Map.of("key3", "val3"), value.get().toMap());
+    }
+
+    @Test
+    public void itSupportsArrayValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<JSONArray> value = new Value<>(new JSONArray("[1,2,3]"), v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "array")));
+        
+        // when updating property, then
+        assertEquals(List.of(1,2,3), value.get().toList());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":[]}"));
+        assertEquals(List.of(), value.get().toList());
+    }
+
+    @Test
+    public void itSupportsStringValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<String> value = new Value<>("the-initial-string", v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "string")));
+        
+        // when updating property, then
+        assertEquals("the-initial-string", value.get());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":\"the-updated-string\"}"));
+        assertEquals("the-updated-string", value.get());
+    }
+
+    @Test
+    public void itSupportsBooleanValues() throws PropertyError
+    {
+        // given
+        Thing thing = new Thing("urn:dev:test-123", "My TestThing");
+
+        Value<Boolean> value = new Value<>(false, v -> System.out.println("value: " + v));
+        thing.addProperty(new Property<>(thing, "p", value, new JSONObject().put("type", "boolean")));
+        
+        // when updating property, then
+        assertFalse(value.get());
+
+        thing.setProperty("p", simulateHttpPutProperty("p", "{\"p\":true}"));
+        assertTrue(value.get());
     }
 }

--- a/src/test/java/io/webthings/webthing/ValueTest.java
+++ b/src/test/java/io/webthings/webthing/ValueTest.java
@@ -1,0 +1,52 @@
+package io.webthings.webthing;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
+
+import java.util.List;
+import java.util.Map;
+
+import org.json.JSONArray;
+import org.json.JSONObject;
+import org.junit.Test;
+
+public class ValueTest {
+
+    @Test
+    public void itKnowsItsBaseTypeAtRuntime()
+    {
+        Value<Double> doubleNull = new Value<>(Double.class);
+        assertEquals(Double.class, doubleNull.getBaseType());
+        assertNull(doubleNull.get());
+
+        Value<Double> doubleByValue = new Value<>(42.0123);
+        assertEquals(Double.class, doubleNull.getBaseType());
+        assertEquals(42.0123, doubleByValue.get(), 0.00001);
+
+        Value<String> stringByValue = new Value<>("my-string-value");
+        assertEquals(String.class, stringByValue.getBaseType());
+        assertEquals("my-string-value", stringByValue.get());
+
+        Value<String> stringNull = new Value<>(String.class, str -> {});
+        assertEquals(String.class, stringByValue.getBaseType());
+        assertNull(stringNull.get());
+
+        Value<JSONArray> listByValue = new Value<>(new JSONArray("[1,2,3]"), list -> {});
+        assertEquals(JSONArray.class, listByValue.getBaseType());
+        assertEquals(List.of(1,2,3), listByValue.get().toList());
+
+        Value<JSONObject> objectExplicit;
+        objectExplicit = new Value<>(JSONObject.class, new JSONObject().put("key", "value"), obj -> {});
+        assertEquals(JSONObject.class, objectExplicit.getBaseType());
+        assertEquals(Map.of("key","value"), objectExplicit.get().toMap());
+    }
+
+    @Test
+    public void itsBaseTypeIsRequiredAtConstruction()
+    {
+        NullPointerException ex;
+        ex = assertThrows(NullPointerException.class, () -> new Value<Boolean>(null, true, bool -> {}));
+        assertEquals("The base type of a value must not be null.", ex.getMessage());
+    }
+}

--- a/src/test/java/io/webthings/webthing/ValueTest.java
+++ b/src/test/java/io/webthings/webthing/ValueTest.java
@@ -4,8 +4,8 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThrows;
 
-import java.util.List;
-import java.util.Map;
+import java.util.Arrays;
+import java.util.Collections;
 
 import org.json.JSONArray;
 import org.json.JSONObject;
@@ -28,18 +28,18 @@ public class ValueTest {
         assertEquals(String.class, stringByValue.getBaseType());
         assertEquals("my-string-value", stringByValue.get());
 
-        Value<String> stringNull = new Value<>(String.class, str -> {});
+        Value<String> stringNull = new Value<>(String.class, (String str) -> {});
         assertEquals(String.class, stringByValue.getBaseType());
         assertNull(stringNull.get());
 
         Value<JSONArray> listByValue = new Value<>(new JSONArray("[1,2,3]"), list -> {});
         assertEquals(JSONArray.class, listByValue.getBaseType());
-        assertEquals(List.of(1,2,3), listByValue.get().toList());
+        assertEquals(Arrays.asList(1, 2, 3), listByValue.get().toList());
 
         Value<JSONObject> objectExplicit;
         objectExplicit = new Value<>(JSONObject.class, new JSONObject().put("key", "value"), obj -> {});
         assertEquals(JSONObject.class, objectExplicit.getBaseType());
-        assertEquals(Map.of("key","value"), objectExplicit.get().toMap());
+        assertEquals(Collections.singletonMap("key", "value"), objectExplicit.get().toMap());
     }
 
     @Test


### PR DESCRIPTION
Hello @benfrancis thanks for your fast response. Here you find a first approach of improving issue #62.

It is surprisingly hard to get the type information at runtime without changing the interface of existing classes. This is as Javas type erasure mechanism discards all type information of generics at compile time.

From what I can see, there are  two possible paths to go:

1. Workaround based on available meta information from the thing description:
  - For this path you can see a change suggestion in Thing.java
  - pro: does not break the interface
  - con: only supports integer input for doubles, floats will not work. Btw at the moment floats are also not working, even when fractional input is given. JSONObject always parses the fractional input to Double, which can't be cast to Float. But is Float really required, or will it be ok to officially only support Double?. This approach only works when "number" is given as type in thing description. It does not perform real type detection but just assumes that Double will be correct type.
   
2. Changing  some basic structures to make type information available at runtime: 
  - This could solve the issue in general and allows more smart helpers
  - To make type information available at runtime, we need to pass the Class<T> to Value<T> and make it available as member variable. This variable then could be used by Property and Thing. Unfortunately null is allowed as default value for Value class. So it is not save to query the class from default value at Value construction. A possible solution would be adding Class parameter to constructor or creating some custom annotation, but this breaks the interface and/or makes it verbose e.g.

```Java
Value<Double> val = new Value<>(Double.class, 12.3, theValue -> {}); // type passed in c'tor
Value<Double> val = new Value<>(Double.class, null, theValue -> {}); // type passed in c'tor
```

```Java
Value<Double> val = new Value<>(12.3, theValue -> {}); // type known from default value

@RememberType(Double.class) // create custom annotation
Value<Double> val = new Value<>(null, theValue -> {}); // annotation presence could be checked in c'tor in case default value is null
```

In addition I added an unit test to demonstrate the issue. (Float will still fail at the moment). So far my thoughts for the moment any comment welcome. Maybe I'm missing something and there is a simpler solution possible?

Best Regards 

Benno



