### PR TITLE
Prepare release 0.15.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,13 +15,9 @@ jobs:
       matrix:
         java-version: [
           '8.0.x',
-          '9.0.x',
-          '10.0.x',
           '11.0.x',
-          '12.0.x',
-          '13.0.x',
-          '14.0.x',
-          '15.0.x',
+          '17.0.x',
+          '21.0.x',
         ]
     steps:
       - uses: actions/checkout@v2

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 [![Maven](https://img.shields.io/maven-central/v/io.webthings/webthing.svg)](https://search.maven.org/#search%7Cgav%7C1%7Cg%3A%22io.webthings%22%20AND%20a%3A%22webthing%22)
 [![license](https://img.shields.io/badge/license-MPL--2.0-blue.svg)](LICENSE)
 
-Implementation of an HTTP [Web Thing](https://iot.mozilla.org/wot/).
+Implementation of an HTTP [Web Thing](https://webthings.io/api).
 
 # Using
 
@@ -17,7 +17,7 @@ Add the following dependency to your project:
     <dependency>
         <groupId>io.webthings</groupId>
         <artifactId>webthing</artifactId>
-        <version>0.14.0</version>
+        <version>0.15.0</version>
     </dependency>
 </dependencies>
 ```
@@ -29,7 +29,7 @@ Add the following dependency to your project:
 ```gradle
 dependencies {
     runtime(
-        [group: 'io.webthings', name: 'webthing', version: '0.14.0'],
+        [group: 'io.webthings', name: 'webthing', version: '0.15.0'],
     )
 }
 ```
@@ -51,7 +51,7 @@ In this example we will set up a dimmable light and a humidity sensor (both usin
 
 ## Dimmable Light
 
-Imagine you have a dimmable light that you want to expose via the web of things API. The light can be turned on/off and the brightness can be set from 0% to 100%. Besides the name, description, and type, a [`Light`](https://iot.mozilla.org/schemas/#Light) is required to expose two properties:
+Imagine you have a dimmable light that you want to expose via the web of things API. The light can be turned on/off and the brightness can be set from 0% to 100%. Besides the name, description, and type, a [`Light`](https://webthings.io/schemas/#Light) is required to expose two properties:
 * `on`: the state of the light, whether it is turned on or off
     * Setting this property via a `PUT {"on": true/false}` call to the REST API toggles the light.
 * `brightness`: the brightness level of the light from 0-100%
@@ -139,7 +139,7 @@ This will start the server, making the light available via the WoT REST API and 
 
 Let's now also connect a humidity sensor to the server we set up for our light.
 
-A [`MultiLevelSensor`](https://iot.mozilla.org/schemas/#MultiLevelSensor) (a sensor that returns a level instead of just on/off) has one required property (besides the name, type, and optional description): **`level`**. We want to monitor this property and get notified if the value changes.
+A [`MultiLevelSensor`](https://webthings.io/schemas/#MultiLevelSensor) (a sensor that returns a level instead of just on/off) has one required property (besides the name, type, and optional description): **`level`**. We want to monitor this property and get notified if the value changes.
 
 First we create a new Thing:
 

--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 
     <groupId>io.webthings</groupId>
     <artifactId>webthing</artifactId>
-    <version>0.14.0</version>
+    <version>0.15.0</version>
 
     <name>WebThing</name>
     <description>Implementation of an HTTP Web Thing.</description>

--- a/test.sh
+++ b/test.sh
@@ -5,7 +5,7 @@ git clone https://github.com/WebThingsIO/webthing-tester
 pip3 install --user -r webthing-tester/requirements.txt
 
 # build the jar
-mvn clean compile assembly:single
+mvn clean compile assembly:single test
 jar=$(find target -type f -name 'webthing-*-jar-with-dependencies.jar')
 
 # build and test the single-thing example


### PR DESCRIPTION
To make fix of #62 available via maven central a new release is required. With this merge request I provide following preparations:
- Increase version number to 0.15.0 in pom.xml
- Update readme to contain new version number + link updates
- Build workflow will build only the LTS Java version 8,11,17,21 
- Update test.sh to let maven execute the junit tests

@tim-hellhake can you review the changes? @benfrancis if changes are accepted can you perform the release? Or am I allowed to push tags?

Thanks in advance, in case anything is missing just let me know.

Best Regards, Benno